### PR TITLE
Fix doc comment for getBufferedWriter

### DIFF
--- a/src/org/jibble/pircbot/DccChat.java
+++ b/src/org/jibble/pircbot/DccChat.java
@@ -184,9 +184,9 @@ public class DccChat {
 
 
     /**
-     * Returns the BufferedReader used by this DCC Chat.
+     * Returns the BufferedWriter used by this DCC Chat.
      *
-     * @return the BufferedReader used by this DCC Chat.
+     * @return the BufferedWriter used by this DCC Chat.
      */
     public BufferedWriter getBufferedWriter() {
         return _writer;


### PR DESCRIPTION
## Summary
- correct documentation on `getBufferedWriter` to mention `BufferedWriter`

## Testing
- `javac -classpath lib/commons-configuration2-2.11.0.jar -d out @sources.txt`

------
https://chatgpt.com/codex/tasks/task_e_684dcd47321083239d04bb416944242f